### PR TITLE
Add `uses` in sitemap routes

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,11 +4,13 @@ import Link from "next/link";
 export function Navbar() {
   return (
     <nav className="flex items-start gap-4 py-12 font-medium tracking-tight">
-      {links.map(({ path, label }) => (
-        <Link href={path} key={label}>
-          {label}
-        </Link>
-      ))}
+      {links
+        .filter((l) => !l.hidden)
+        .map(({ path, label }) => (
+          <Link href={path} key={label}>
+            {label}
+          </Link>
+        ))}
     </nav>
   );
 }

--- a/src/lib/consts.ts
+++ b/src/lib/consts.ts
@@ -4,7 +4,11 @@ export const author = {
 
 export const projectURL = "https://rohi.dev";
 
-export const links: Array<{ path: `/${string}`; label: string }> = [
+export const links: Array<{
+  path: `/${string}`;
+  label: string;
+  hidden?: boolean;
+}> = [
   {
     path: "/",
     label: "home",
@@ -12,4 +16,5 @@ export const links: Array<{ path: `/${string}`; label: string }> = [
   { path: "/blog", label: "blog" },
   { path: "/guestbook", label: "guestbook" },
   { path: "/activity", label: "activity" },
+  { path: "/uses", label: "uses", hidden: true },
 ];


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # TL;DR
> This pull request introduces a new feature to the navigation bar component that allows certain links to be hidden. This is achieved by adding a new optional `hidden` property to the `links` array in `consts.ts`.
> 
> # What changed
> Two files were modified:
> 
> 1. `src/components/navbar.tsx`: The `Navbar` function now filters out any links that have the `hidden` property set to `true` before rendering them.
> 
> 2. `src/lib/consts.ts`: The `links` array now includes an optional `hidden` property for each link. This property is a boolean that determines whether the link should be displayed in the navigation bar.
> 
> # How to test
> To test this change, follow these steps:
> 
> 1. Pull the changes from this pull request.
> 2. Start the application.
> 3. Check the navigation bar. It should not display any links that have the `hidden` property set to `true`.
> 4. Modify the `hidden` property of a link in `consts.ts` and refresh the application. The navigation bar should reflect this change.
> 
> # Why make this change
> This change allows for greater flexibility when managing the links in the navigation bar. By adding the `hidden` property, we can easily control which links are displayed without having to remove them from the `links` array. This is particularly useful for links that are only relevant at certain times or for certain users.
</details>